### PR TITLE
Fixed getLanguageNames function

### DIFF
--- a/language-list.js
+++ b/language-list.js
@@ -27,7 +27,7 @@ LanguageList.prototype.getLanguageName = function getLanguageNames(code) {
 
 LanguageList.prototype.getLanguageNames = function getLanguageNames() {
   return data.map(function(language) {
-    return language.name;
+    return language.language;
   });
 };
 


### PR DESCRIPTION
It returned language.name, but it should be language.language.